### PR TITLE
Use '|' to split the data.

### DIFF
--- a/main.go
+++ b/main.go
@@ -220,6 +220,12 @@ func listTables(name string) ([]string, []string, error) {
 }
 
 func loadCSV(name string) error {
+
+	_, err := db.Exec("set global local_infile = 'ON'")
+	if err != nil {
+		return err
+	}
+
 	root := path.Join(output, name, "csv")
 	if useSample {
 		root = path.Join(input, name, "samples")
@@ -242,7 +248,8 @@ func loadCSV(name string) error {
 
 		start := time.Now()
 		fmt.Printf("begin to load csv %s into %s\n", filePath, tableName)
-		_, err := db.Exec("LOAD DATA LOCAL INFILE '" + filePath + "' INTO TABLE " + tableName)
+		_, err := db.Exec("LOAD DATA LOCAL INFILE '" + filePath + "' INTO TABLE " + tableName +
+			" FIELDS TERMINATED BY '|' OPTIONALLY ENCLOSED BY '\"' LINES TERMINATED BY '\\n'")
 		mysql.DeregisterLocalFile(filePath)
 
 		if err != nil {

--- a/main.go
+++ b/main.go
@@ -219,12 +219,17 @@ func listTables(name string) ([]string, []string, error) {
 	return tables, tableSQLs, nil
 }
 
-func loadCSV(name string) error {
-
-	_, err := db.Exec("set global local_infile = 'ON'")
+func loadCSV(name string) (err error) {
+	_, err = db.Exec("set global local_infile = 'ON'")
 	if err != nil {
 		return err
 	}
+	defer func() {
+		_, err2 := db.Exec("set global local_infile = 'OFF'")
+		if err == nil {
+			err = err2
+		}
+	}()
 
 	root := path.Join(output, name, "csv")
 	if useSample {


### PR DESCRIPTION
In the csv files, it uses '|' to split the data. 

To load data , I set the global variable `local_infile` to `ON`.
In TiDB,
Default Value is OFF
In Mysql, 
Default Value (version >= 8.0.2) is OFF 
Default Value (version <= 8.0.1)  is ON

